### PR TITLE
Username display fixes

### DIFF
--- a/resources/index.gui
+++ b/resources/index.gui
@@ -20,6 +20,11 @@
     <use href="#fitfont-char"/>
     <use href="#fitfont-char"/>
     <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
   </use>
 
   <!-- Left Labels -->
@@ -210,6 +215,11 @@
 
   <!-- Bottom command -->
   <use id="BOTTOM" x="5" y="255" href="#fitfont">
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
+    <use href="#fitfont-char"/>
     <use href="#fitfont-char"/>
     <use href="#fitfont-char"/>
     <use href="#fitfont-char"/>

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -11,6 +11,7 @@ const safeJsonParse = (json, fallback = []) => {
 registerSettingsPage((props) => {
   const hasElevationGain = props.settingsStorage.getItem('hasElevationGain') === 'true';
   const OPTIONS_DATA_POINTS = getPossibleDatalineOptions({ hasElevationGain });
+  const isLongUsername = (safeJsonParse(props.settings.username).name || '').length > 8;
 
   return (
     <Page>
@@ -23,6 +24,8 @@ registerSettingsPage((props) => {
           settingsKey="username"
           action="sudo usermod -l"
         />
+        {isLongUsername &&
+          <Text italic>Warning: usernames longer than 8 characters may cause other text to become clipped.</Text>}
         <Select
           label="Font"
           settingsKey="font"


### PR DESCRIPTION
- Fix display of username longer than 4 char (#14)
- Add warning in settings if username is longer than 8 char

<img width="1528" alt="Screen Shot 2020-09-21 at 5 59 11 PM" src="https://user-images.githubusercontent.com/405538/93835538-674fbf80-fc34-11ea-801d-886be89cafd6.png">
