### PR TITLE
Add "Time with seconds" dataline

### DIFF
--- a/app/datalines/Dataline.js
+++ b/app/datalines/Dataline.js
@@ -1,12 +1,17 @@
 import { swapClass } from '../utils';
 
-export default function Dataline({ name, updateValue, start, stop, checkPermissions }) {
+export default function Dataline({ name, updateValue, start, stop, checkPermissions, ...rest }) {
     this.isActive = false;
 
     this.name = name;
     this.updateValue = updateValue.bind(this);
     this.start = start.bind(this);
     this.stop = stop.bind(this);
+
+    // Promote other properties to the instance
+    Object.keys(rest).forEach((key) => {
+        this[key] = rest[key];
+    });
 
     if (checkPermissions) {
         this.checkPermissions = checkPermissions.bind(this);

--- a/app/datalines/time.js
+++ b/app/datalines/time.js
@@ -4,16 +4,21 @@ import { preferences } from 'user-settings';
 import Dataline from './Dataline';
 import { zeroPad, swapClass } from '../utils';
 
-export default new Dataline({
+export default ({
+    showSeconds = false
+} = {}) => new Dataline({
     name: 'TIME',
+    showSeconds,
     updateValue(event = {}) {
+        const is12HrFormat = preferences.clockDisplay === '12h';
         const date = event.date || new Date();
 
         let meridiem = '';
         let hours = date.getHours();
         const mins = zeroPad(date.getMinutes());
+        const secs = this.showSeconds ? `:${zeroPad(date.getSeconds()) }` : '';
 
-        if (preferences.clockDisplay === '12h') {
+        if (is12HrFormat) {
             meridiem = hours < 12 ? ' AM' : ' PM';
             hours = hours % 12 || 12;
         } else {
@@ -23,13 +28,14 @@ export default new Dataline({
         const rawOffset = date.getTimezoneOffset();
         const absoluteOffset = Math.abs(rawOffset);
         const offset = [
+            is12HrFormat && this.showSeconds && hours > 9 ? '' : ' ',
             (rawOffset < 0 ? '+' : '-'),
             ('00' + Math.floor(absoluteOffset / 60)).slice(-2),
             ':',
             ('00' + (absoluteOffset % 60)).slice(-2),
         ].join('');
 
-        this.valueRef.text = `${hours}:${mins}${meridiem} ${offset}`;
+        this.valueRef.text = `${hours}:${mins}${secs}${meridiem}${offset}`;
         swapClass(this.valueRef.root, 'color', 'green');
     },
     start() {
@@ -37,5 +43,5 @@ export default new Dataline({
     },
     stop() {
         clock.removeEventListener('tick', this.updateValue);
-    }
+    },
 });

--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,7 @@ import { peerSocket } from 'messaging';
 import onSettingsChange from './settings';
 import { hasElevationGain } from './config';
 
-import TIME from './datalines/time';
+import timeFactory from './datalines/time';
 import DATE from './datalines/date';
 import BATT from './datalines/battery';
 import STEP from './datalines/steps';
@@ -38,8 +38,9 @@ const host = String(device.modelName)
     .toLowerCase();
 
 
-
-const allDatalines = { TIME, DATE, BATT, STEP, DIST, LVLS, HRRT, CALS, AZMS };
+const TIME = timeFactory({ showSeconds: false });
+const TIMESECS = timeFactory({ showSeconds: true });
+const allDatalines = { TIME, TIMESECS, DATE, BATT, STEP, DIST, LVLS, HRRT, CALS, AZMS };
 
 let updatePromptLine;
 

--- a/common/settings.js
+++ b/common/settings.js
@@ -1,5 +1,6 @@
 const DATA_LINE_MAP = {
     TIME: 'Time',
+    TIMESECS: 'Time with seconds',
     DATE: 'Date',
     BATT: 'Battery',
     STEP: 'Step count',


### PR DESCRIPTION
Closes #50 

Add new "Time with seconds" dataline; use the same dataline class, but with a `showSeconds` boolean property set to true.

Space gets a little tight when showing seconds at 2-digit hours in 12 hr mode. To avoid clipping, I have trimmed the space before the offset in this case, so we see `12:00:00 PM-06:00:00` in this case.

### Screenshots
<img src=https://user-images.githubusercontent.com/405538/219242232-06682a77-700e-463f-97b8-b6c523f50a63.png height=180>

**24 hour time**
<img src=https://user-images.githubusercontent.com/405538/219242318-2b837260-8bc3-41b2-a79d-d935e149c6e6.png height=180>

**Compressed whitespace**
<img src=https://user-images.githubusercontent.com/405538/219242443-cc67eb0e-5f3e-4406-8e57-9cc02720c163.png height=180>
